### PR TITLE
Add node_modules and coverage in npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
+node_modules
+coverage
 test
 example
 .eslintrc.yaml


### PR DESCRIPTION
The directory `coverage` are published on _npm_. I add this directory and `node_modules` (copied from `.gitignore`) in `.npmignore`.